### PR TITLE
Import order fix from Kazu

### DIFF
--- a/Makefile/GNUmakefile.CORE
+++ b/Makefile/GNUmakefile.CORE
@@ -17,7 +17,7 @@ ifdef HEADERS_DEST
 $(shell mkdir -p $(PACKAGE_INCDIR))
 endif
 
-DICT    = $(PACKAGE_BUILDDIR)/$(PACKAGE_NAME)Dict
+DICT    = $(PACKAGE_BUILDDIR)/FlashMatch$(PACKAGE_NAME)Dict
 OBJECTS = $(addprefix $(PACKAGE_BUILDDIR)/, $(SOURCES:.cxx=.o))
 
 all: pre_build main_build pkg_build
@@ -31,7 +31,7 @@ $(PACKAGE_BUILDDIR)/%.o: %.cxx %.h
 	@echo '<< compiling' $< '>>'
 	@$(CXX) $(CXXFLAGS) $(FMATCH_BASIC_ROOTINC) $(INCFLAGS) -DFMATCH_NUMPY=$(FMATCH_NUMPY) -DUSING_LARSOFT=0 -c $< -o $@
 $(DICT).o: $(DICT).cxx
-	@echo '<< compiling' $(PACKAGE_NAME)Dict.cxx '>>'
+	@echo '<< compiling' $(DICT).cxx '>>'
 	@$(CXX) $(CXXFLAGS) $(FMATCH_BASIC_ROOTINC) $(INCFLAGS) -DUSING_LARSOFT=0 -c $< -o $@
 
 # root class dictionary

--- a/flashmatch/PyUtil/FMatchPyUtils.cxx
+++ b/flashmatch/PyUtil/FMatchPyUtils.cxx
@@ -1,7 +1,7 @@
-#ifndef __OPT0FINDER_PYUTILS_CXX__
-#define __OPT0FINDER_PYUTILS_CXX__
+#ifndef __FMATCHPYUTILS_CXX__
+#define __FMATCHPYUTILS_CXX__
 
-#include "PyUtils.h"
+#include "FMatchPyUtils.h"
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 //#include <numpy/ndarrayobject.h>
 #include "numpy/arrayobject.h"
@@ -11,7 +11,7 @@
 
 namespace flashmatch {
 
-  void SetPyUtil() {
+  void SetFMatchPyUtil() {
     static bool once = false;
     if (!once) {
       _import_array();
@@ -20,7 +20,7 @@ namespace flashmatch {
   }
 
   geoalgo::Trajectory as_geoalgo_trajectory(PyObject* pyarray) {
-    ::flashmatch::SetPyUtil();
+    ::flashmatch::SetFMatchPyUtil();
     double **carray;
     const int dtype = NPY_DOUBLE;
     PyArray_Descr *descr = PyArray_DescrFromType(dtype);
@@ -39,7 +39,7 @@ namespace flashmatch {
   }  
 
   PyObject* as_ndarray(const QCluster_t& traj) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     std::vector<size_t> dims(2,0);
     dims[0] = traj.size();
     dims[1] = 4;
@@ -66,7 +66,7 @@ namespace flashmatch {
   }
 
   PyObject* as_ndarray(const ::geoalgo::Trajectory& traj) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     std::vector<size_t> dims(2,0);
     dims[0] = traj.size();
     dims[1] = 3;
@@ -92,7 +92,7 @@ namespace flashmatch {
   }
 
   PyObject* as_ndarray(const Flash_t& flash) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     std::vector<size_t> dims(1);
     dims[0] = flash.pe_v.size();
     auto pyarray = numpy_array<double>(dims);
@@ -115,7 +115,7 @@ namespace flashmatch {
 
   /*
     void copy_array(PyObject *arrayin, const std::vector<float> &cvec) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     PyArrayObject *ptr = (PyArrayObject *)(arrayin);
     
     //std::cout<< PyArray_NDIM(ptr) << std::endl
@@ -141,7 +141,7 @@ namespace flashmatch {
   
   template<class T>
   void _copy_array(PyObject *arrayin, const std::vector<T> &cvec) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     PyArrayObject *ptr = (PyArrayObject *)(arrayin);
     
     //std::cout<< PyArray_NDIM(ptr) << std::endl
@@ -180,18 +180,18 @@ namespace flashmatch {
   void copy_array(PyObject *arrayin, const std::vector< float          > &cvec) { _copy_array(arrayin, cvec); }
   void copy_array(PyObject *arrayin, const std::vector< double         > &cvec) { _copy_array(arrayin, cvec); }
   
-  template<> int ctype_to_numpy<short>() { SetPyUtil(); SetPyUtil(); return NPY_INT16; }
-  template<> int ctype_to_numpy<unsigned short>() { SetPyUtil(); return NPY_UINT16; }
-  template<> int ctype_to_numpy<int>() { SetPyUtil(); return NPY_INT32; }
-  template<> int ctype_to_numpy<unsigned int>() { SetPyUtil(); return NPY_UINT32; }
-  template<> int ctype_to_numpy<long long>() { SetPyUtil(); return NPY_INT64; }
-  template<> int ctype_to_numpy<unsigned long long>() { SetPyUtil(); return NPY_UINT64; }
-  template<> int ctype_to_numpy<float>() { SetPyUtil(); return NPY_FLOAT32; }
-  template<> int ctype_to_numpy<double>() { SetPyUtil(); return NPY_FLOAT64; }
+  template<> int ctype_to_numpy<short>() { SetFMatchPyUtil(); SetFMatchPyUtil(); return NPY_INT16; }
+  template<> int ctype_to_numpy<unsigned short>() { SetFMatchPyUtil(); return NPY_UINT16; }
+  template<> int ctype_to_numpy<int>() { SetFMatchPyUtil(); return NPY_INT32; }
+  template<> int ctype_to_numpy<unsigned int>() { SetFMatchPyUtil(); return NPY_UINT32; }
+  template<> int ctype_to_numpy<long long>() { SetFMatchPyUtil(); return NPY_INT64; }
+  template<> int ctype_to_numpy<unsigned long long>() { SetFMatchPyUtil(); return NPY_UINT64; }
+  template<> int ctype_to_numpy<float>() { SetFMatchPyUtil(); return NPY_FLOAT32; }
+  template<> int ctype_to_numpy<double>() { SetFMatchPyUtil(); return NPY_FLOAT64; }
   
   /*
     PyObject *as_ndarray(const std::vector<float> &vec) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     
     if (vec.size() >= INT_MAX) {
     LARCV_CRITICAL() << "Length of data vector too long to specify ndarray. "
@@ -210,7 +210,7 @@ namespace flashmatch {
   
   template <class T>
   PyObject *_as_ndarray(const std::vector<T> &vec) {
-    SetPyUtil();
+    SetFMatchPyUtil();
     
     if (vec.size() >= INT_MAX) {
       std::cerr << "Length of data vector too long to specify ndarray. " << std::endl;
@@ -245,7 +245,7 @@ namespace flashmatch {
   template<class T>
   PyObject* numpy_array(std::vector<size_t> dims)
   {
-    SetPyUtil();
+    SetFMatchPyUtil();
     int nd_ = dims.size();
     npy_intp dims_[nd_];
     for(size_t i=0; i<dims.size(); ++i) dims_[i] = dims[i];

--- a/flashmatch/PyUtil/FMatchPyUtils.h
+++ b/flashmatch/PyUtil/FMatchPyUtils.h
@@ -1,5 +1,5 @@
-#ifndef __OPT0FINDER_PYUTILS_H__
-#define __OPT0FINDER_PYUTILS_H__
+#ifndef __FMATCHPYUTILS_H__
+#define __FMATCHPYUTILS_H__
 
 struct _object;
 typedef _object PyObject;
@@ -13,7 +13,7 @@ typedef _object PyObject;
 #include "flashmatch/GeoAlgo/GeoTrajectory.h"
 namespace flashmatch {
   /// Utility function: call one-time-only numpy module initialization (you don't have to call)
-  void SetPyUtil();
+  void SetFMatchPyUtil();
 
   ::geoalgo::Trajectory as_geoalgo_trajectory(PyObject* pyarray);
   PyObject* as_ndarray(const QCluster_t& traj);


### PR DESCRIPTION
This fixes an issue with OpT0Finder crashing when import order between `larcv` and `flashmatch` is swapped. 