### PR TITLE
Modify chi2, add ability to mask out unused channels

### DIFF
--- a/dat/detector_specs_sbnd.cfg
+++ b/dat/detector_specs_sbnd.cfg
@@ -55,8 +55,6 @@ DetectorSpecs: {
         ,280,281,282,283,284,285,286,287,288,289,290,291,292,293,306,307,308,309,310,311
     ]
 
-    # Coated / Visible OpDet
-
     #Disk detector (else from larsoft)
 
     #Use the configuration below if using XA and PMTs

--- a/dat/detector_specs_sbnd.cfg
+++ b/dat/detector_specs_sbnd.cfg
@@ -55,6 +55,8 @@ DetectorSpecs: {
         ,280,281,282,283,284,285,286,287,288,289,290,291,292,293,306,307,308,309,310,311
     ]
 
+    # Coated / Visible OpDet
+
     #Disk detector (else from larsoft)
 
     #Use the configuration below if using XA and PMTs

--- a/flashmatch/Algorithms/PhotonLibHypothesis.cxx
+++ b/flashmatch/Algorithms/PhotonLibHypothesis.cxx
@@ -199,8 +199,7 @@ namespace flashmatch {
                 double qsum = 0.;
                 double vsum = 0.;
                 for(size_t ipmt=0; ipmt < n_pmt; ++ipmt) {
-
-                    if(_channel_mask[ipmt] < 0) continue; //this is a vector of ints, mapping an index to a pmt
+                    if(_channel_mask[ipmt] == false) continue; //this is a vector of ints, mapping an index to a pmt
 
                     if(!_uncoated_pmt_list[ipmt])
 		      local_pe_v[ipmt] += pt.q * lib_data[ipmt];

--- a/flashmatch/Algorithms/PhotonLibHypothesis.cxx
+++ b/flashmatch/Algorithms/PhotonLibHypothesis.cxx
@@ -55,15 +55,16 @@ namespace flashmatch {
         if(flash.pe_v.empty()) flash.pe_v.resize(n_pmt);
         if(flash.pe_err_v.empty()) flash.pe_err_v.resize(n_pmt);
         if(flash.pe_true_v.empty()) flash.pe_true_v.resize(n_pmt);
+        if(flash.closest_pds_v.empty()) flash.closest_pds_v.resize(n_pmt);
 
         assert(flash.pe_v.size()     == n_pmt);
         assert(flash.pe_true_v.size() == n_pmt);
         assert(flash.pe_err_v.size() == n_pmt);
-
+        assert(flash.closest_pds_v.size() == n_pmt);
         for (auto& v : flash.pe_v      ) {v = 0;}
         for (auto& v : flash.pe_err_v  ) {v = 0;}
         for (auto& v : flash.pe_true_v ) {v = 0;}
-
+        for (auto& v : flash.closest_pds_v) {v = 1e9;}
         double track_length = tpc_trk.front().dist(tpc_trk.back());
         int touch = this->InspectTouchingEdges(tpc_trk);
         bool extend_tracks = (_extend_tracks && touch && track_length < _threshold_track_len);

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -266,8 +266,6 @@ namespace flashmatch {
       double msum = std::accumulate(one_measurement.pe_v.begin(), one_measurement.pe_v.end(), 0.0);
       if (hsum!=0) for (auto &v : one_hypothesis.pe_v) v /= hsum;
       if (msum!=0) for (auto &v : one_measurement.pe_v) v /= msum;
-      _msum = msum; // store the sum of PE in the measurement before any normalization
-      _hsum = hsum; // store the sum of PE in the hypothesis before any normalization
       // Scale the pe normalization factor if normalizing the flashes and hypothesis
       FLASH_DEBUG() << "Scaling observation threshold by " << 1/msum << std::endl;
       if (msum!=0) _pe_observation_threshold_scaled = _pe_observation_threshold / msum;

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -33,8 +33,8 @@ namespace flashmatch {
     _chi_error = pset.get<double>("ChiErrorWidth", 0.0);
     _chi_error_min = pset.get<double>("ChiErrorMin", 1.0); // minimum poisson uncertainty on flash in PE. Normalized flashes are scaled by total PE.
     _chi_error_min_scaled = _chi_error_min;
-    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.e-12);
-    _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold", 1.e-12);
+    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 0.);
+    _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold",0.);
     _pe_observation_threshold_scaled = _pe_observation_threshold;
     _migrad_tolerance         = pset.get<double>("MIGRADTolerance", 0.1);
     _offset                   = pset.get<double>("Offset", 0.0);

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -75,6 +75,13 @@ namespace flashmatch {
     auto const& bbox = DetectorSpecs::GetME().ActiveVolume();
     _vol_xmax = bbox.Max()[0];
     _vol_xmin = bbox.Min()[0];
+
+    // Configuration statements
+    FLASH_NORMAL() << "QLLMatch configuration: " << std::endl;
+    FLASH_NORMAL() << "  - Mode: " << _mode << std::endl;
+    FLASH_NORMAL() << "  - PE observation threshold: " << _pe_observation_threshold << std::endl;
+    FLASH_NORMAL() << "  - PE hypothesis threshold: " << _pe_hypothesis_threshold << std::endl;
+    
   }
 
 
@@ -211,7 +218,7 @@ namespace flashmatch {
     auto    one_measurement = flash;
 
     for (size_t ich = 0; ich < DetectorSpecs::GetME().NOpDets(); ++ich ) {
-      if (_match_mask.at(ich) != 0){
+      if (_match_mask.at(ich) != 0 && _channel_mask.at(ich)){
           one_hypothesis.pe_v[ich] = 0.;
           one_measurement.pe_v[ich] = 0.;
       }
@@ -223,15 +230,16 @@ namespace flashmatch {
     if (_saturated_thresh > 0){
       for (size_t ich = 0; ich < DetectorSpecs::GetME().NOpDets(); ++ich ) {
         // if above the saturated threshold, measured is zero, is a PMT, and is not masked 
-        if ((one_hypothesis.pe_v[ich] >= _saturated_thresh) && (one_measurement.pe_v[ich] == 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0)){
+        if ((one_hypothesis.pe_v[ich] >= _saturated_thresh) && (one_measurement.pe_v[ich] == 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0) && _channel_mask.at(ich)){
           FLASH_DEBUG() << "Guessing " << ich << " is saturated, setting hypothesis to 0" << std::endl;
           one_hypothesis.pe_v[ich] = 0;
           continue;
         }
         // if above the nonlinear threshold AND a pmt AND not masked, correct for the nonlinear effect 
-        if ((one_hypothesis.pe_v[ich] > _nonlinear_thresh) && (one_measurement.pe_v[ich] != 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0)){
+        if ((one_hypothesis.pe_v[ich] > _nonlinear_thresh) && (one_measurement.pe_v[ich] != 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0) && _channel_mask.at(ich)){
           double corr_pe = one_hypothesis.pe_v[ich]*_nonlinear_slope + _nonlinear_offset; 
           one_hypothesis.pe_v[ich] = corr_pe;
+          FLASH_DEBUG() << "Correcting " << ich << " from " << one_hypothesis.pe_v[ich] << " to " << corr_pe << std::endl;
         }
       }
     }
@@ -241,16 +249,17 @@ namespace flashmatch {
 
     
     if (_normalize){
-      // Scale the pe normalization factor if normalizing the flashes and hypothesis
-      FLASH_DEBUG() << "Scaling observation threshold by " << 1/one_measurement.TotalPE() << std::endl;
-      _pe_observation_threshold_scaled = _pe_observation_threshold / one_measurement.TotalPE();
-      FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << std::endl;
       // FLASH_DEBUG() << "Scaling hypothesis threshold by " << 1/_hypothesis.TotalPE() << std::endl;
       //_pe_hypothesis_threshold /= _hypothesis.TotalPE();
       double hsum = std::accumulate(one_hypothesis.pe_v.begin(),  one_hypothesis.pe_v.end(), 0.0);
       double msum = std::accumulate(one_measurement.pe_v.begin(), one_measurement.pe_v.end(), 0.0);
       if (hsum!=0) for (auto &v : one_hypothesis.pe_v) v /= hsum;
       if (msum!=0) for (auto &v : one_measurement.pe_v) v /= msum;
+      // Scale the pe normalization factor if normalizing the flashes and hypothesis
+      FLASH_DEBUG() << "Scaling observation threshold by " << 1/msum << std::endl;
+      FLASH_DEBUG() << "Measurement total PE: " << one_measurement.TotalPE() << std::endl;
+      if (msum!=0) _pe_observation_threshold_scaled = _pe_observation_threshold / msum;
+      FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << std::endl;
     }
 
     // perform likelihood calculation
@@ -390,7 +399,7 @@ namespace flashmatch {
     for(size_t i=0; i<_exp_frac_v.size(); ++i) {
       integral_factor += _exp_frac_v[i] * (1 - exp(-1 * measurement.time_width / _exp_tau_v[i]));
     }
-    FLASH_DEBU() << "Integral factor: " << integral_factor << std::endl;
+    FLASH_DEBUG() << "Integral factor: " << integral_factor << std::endl;
     assert(integral_factor > 0);
 
     double O, H, Error;
@@ -509,14 +518,23 @@ namespace flashmatch {
 
       	Error = O;
         //Error = (std::pow(H*_chi_error,2)+O);
-        if( Error < 1.0 ) Error = 1.0;
+        if( Error < _pe_observation_threshold_scaled ) Error = _pe_observation_threshold_scaled;
         //double chi2 = std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2));
         double chi2 = std::pow((O - H), 2) / (Error);
         _current_chi2 += chi2;
-        if(!(O==_pe_observation_threshold_scaled && H == _pe_hypothesis_threshold)) FLASH_DEBUG() <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2)) << std::endl;
+        //if(!(O==_pe_observation_threshold_scaled && H == _pe_hypothesis_threshold)) 
+        FLASH_DEBUG() <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << chi2 << std::endl;
         nvalid_pmt += 1;
 
-      } else {
+      } 
+      else if (_mode == kGStat) {
+        //https://www.biostathandbook.com/gtestgof.html#chivsg - handles large differences in O and H
+        double arg = -2*std::log(H/O)*O;
+        _current_chi2 += arg;
+        FLASH_DEBUG() <<"GStat | O | H | G : "<<pmt_index<<", " << O << ", " << H << ", " << arg << std::endl;
+        nvalid_pmt += 1;
+      }
+      else {
       	FLASH_ERROR() << "Unexpected mode" << std::endl;
       	throw OpT0FinderException();
       }
@@ -525,11 +543,33 @@ namespace flashmatch {
     _current_chi2 /= nvalid_pmt;
     _current_llhd /= (nvalid_pmt +1);
 
-    if(_converged)
-      FLASH_INFO() << "Combined LLHD: " << _current_llhd << " (divided by nvalid_pmt+1 = " << nvalid_pmt+1<<")"<<std::endl;
+    if(_converged) {
       FLASH_INFO() << "Combined Chi2: " << _current_chi2 << " (divided by nvalid_pmt = " << nvalid_pmt<<")"<<std::endl;
+    }
 
-    return (_mode == kChi2 ? _current_chi2 : _current_llhd);
+    if(_mode == kGStat || _mode == kChi2) {
+      if (_converged) {
+        FLASH_INFO() << "Combined Chi2: " << _current_chi2 << " (divided by nvalid_pmt = " << nvalid_pmt<<")"<<std::endl;
+      }
+      if (_current_chi2 < 0) {
+        if (_mode == kGStat) {
+          FLASH_DEBUG() << "Combined GStat is negative: " << _current_chi2 
+          << " this can happen when O>H for PDS." << std::endl;
+        }
+        else {
+          FLASH_CRITICAL() << "Combined Chi2 is negative: " << _current_chi2 
+          << " for tpc " << _tpc << " and flash " << measurement.idx << std::endl;
+          throw OpT0FinderException();
+        }
+      }
+      return _current_chi2;
+    }
+    else {
+      if (_converged) {
+        FLASH_INFO() << "Combined LLHD: " << _current_llhd << " (divided by nvalid_pmt+1 = " << nvalid_pmt+1<<")"<<std::endl;
+      }
+      return _current_llhd;
+    }
   }
 
   void MIN_vtx_qll(Int_t & /*Npar*/, // Number of parameters

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -35,7 +35,6 @@ namespace flashmatch {
     _chi_error_min_scaled = _chi_error_min;
     _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 0.);
     _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold",0.);
-    _pe_observation_threshold_scaled = _pe_observation_threshold;
     _migrad_tolerance         = pset.get<double>("MIGRADTolerance", 0.1);
     _offset                   = pset.get<double>("Offset", 0.0);
 		_time_shift               = pset.get<double>("BeamTimeShift", 0.0);
@@ -284,11 +283,10 @@ namespace flashmatch {
       // Scale the pe normalization factor if normalizing the flashes and hypothesis
       FLASH_DEBUG() << "Scaling observation threshold by " << 1/msum << std::endl;
       if (msum!=0){
-        _pe_observation_threshold_scaled = _pe_observation_threshold / msum; // Not used, but keep in case one wants to use it at a later date
         _chi_error_min_scaled = _chi_error_min / msum;
       }
 
-      FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << " and chi error min: " << _chi_error_min_scaled << std::endl;
+      FLASH_DEBUG() << "New chi error min: " << _chi_error_min_scaled << std::endl;
     }
 
     // perform likelihood calculation
@@ -508,7 +506,7 @@ namespace flashmatch {
       }
       else if(_mode == kZIP) {
         double pzero = H > _pe_hypothesis_threshold ? 0. : 1.;
-        double arg = O > _pe_observation_threshold_scaled ? (TMath::Poisson(O,H) * (1-pzero) + epsilon) : (pzero + (1 - pzero)*TMath::Exp(-H) + epsilon);
+        double arg = O > _pe_observation_threshold ? (TMath::Poisson(O,H) * (1-pzero) + epsilon) : (pzero + (1 - pzero)*TMath::Exp(-H) + epsilon);
         if(!std::isnan(arg) && !std::isinf(arg)) {
             _current_llhd -= std::log10(arg);
             nvalid_pmt += 1;

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -30,9 +30,11 @@ namespace flashmatch {
     _check_touching_track = pset.get<bool>("CheckTouchingTrack");
     _normalize = pset.get<bool>("NormalizeHypothesis");
     _mode   = (QLLMode_t)(pset.get<unsigned short>("QLLMode"));
-    _chi_error = pset.get<double>("ChiErrorWidth", 0.1);
-    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.); // This is to avoid divergences in the likelihood function. Asserts a lower bound on the statistical uncertainty in PE.
-    _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold", 1.e-6);
+    _chi_error = pset.get<double>("ChiErrorWidth", 0.0);
+    _chi_error_min = pset.get<double>("ChiErrorMin", 1.0); // minimum poisson uncertainty on flash in PE. Normalized flashes are scaled by total PE.
+    _chi_error_min_scaled = _chi_error_min;
+    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.e-12);
+    _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold", 1.e-12);
     _pe_observation_threshold_scaled = _pe_observation_threshold;
     _migrad_tolerance         = pset.get<double>("MIGRADTolerance", 0.1);
     _offset                   = pset.get<double>("Offset", 0.0);
@@ -43,6 +45,7 @@ namespace flashmatch {
     //Below is used in semi-analytical method
     _many_to_many             = pset.get<bool>("UseManyToMany", true);
     _saturated_thresh = pset.get<double>("SaturatedThreshold", -1);
+    _distance_threshold = pset.get<double>("SaturatedDistanceThreshold", -1); // Distance threshold in cm. If a flash PE is 0 and the distance to the PMT is less than this threshold, assume that the flash PE is 0 due to saturation.
     _nonlinear_thresh = pset.get<double>("NonLinearThreshold", 5e3);
     _nonlinear_slope  = pset.get<double>("NonLinearSlope", 0.75);
     _nonlinear_offset = pset.get<double>("NonLinearOffset", 0.75e3);
@@ -81,6 +84,7 @@ namespace flashmatch {
     FLASH_NORMAL() << "PE observation threshold: " << _pe_observation_threshold << std::endl;
     FLASH_NORMAL() << "PE hypothesis threshold: " << _pe_hypothesis_threshold << std::endl;
     FLASH_NORMAL() << "Chi error width: " << _chi_error << std::endl;
+    FLASH_NORMAL() << "Chi error min: " << _chi_error_min << std::endl;
     FLASH_NORMAL() << "Normalize: " << _normalize << std::endl;
     FLASH_NORMAL() << "MIGRAD tolerance: " << _migrad_tolerance << std::endl;
     FLASH_NORMAL() << "Offset: " << _offset << std::endl;
@@ -89,6 +93,7 @@ namespace flashmatch {
     FLASH_NORMAL() << "Minuit x buffer: " << _minuit_x_buffer << std::endl;
     FLASH_NORMAL() << "Use many-to-many: " << _many_to_many << std::endl;
     FLASH_NORMAL() << "Saturated threshold: " << _saturated_thresh << std::endl;
+    FLASH_NORMAL() << "Saturated distance threshold: " << _distance_threshold << std::endl;
     FLASH_NORMAL() << "Nonlinear threshold: " << _nonlinear_thresh << std::endl;
     FLASH_NORMAL() << "Nonlinear slope: " << _nonlinear_slope << std::endl;
     FLASH_NORMAL() << "Nonlinear offset: " << _nonlinear_offset << std::endl;
@@ -240,8 +245,6 @@ namespace flashmatch {
     //   measured flash PE was set to 0 due to saturation
     if (_saturated_thresh > 0){
       for (size_t ich = 0; ich < DetectorSpecs::GetME().NOpDets(); ++ich ) {
-        FLASH_DEBUG() << "Checking " << ich << " for saturation" << std::endl;
-        FLASH_DEBUG() << "Hypothesis: " << one_hypothesis.pe_v[ich] << " Measurement: " << one_measurement.pe_v[ich] << std::endl;
         // if above the saturated threshold, measured is zero, is a PMT, and is not masked 
         if ((one_hypothesis.pe_v[ich] >= _saturated_thresh) && (one_measurement.pe_v[ich] == 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0) && _channel_mask.at(ich)){
           FLASH_DEBUG() << "Guessing " << ich << " is saturated, setting hypothesis to 0" << std::endl;
@@ -253,6 +256,18 @@ namespace flashmatch {
           double corr_pe = one_hypothesis.pe_v[ich]*_nonlinear_slope + _nonlinear_offset; 
           one_hypothesis.pe_v[ich] = corr_pe;
           FLASH_DEBUG() << "Correcting " << ich << " from " << one_hypothesis.pe_v[ich] << " to " << corr_pe << std::endl;
+        }
+      }
+    }
+    
+    // when the flash PE is 0 and the distance to the PMT is less than the threshold, set the flash PE to 0
+    if (_distance_threshold > 0){
+      for (size_t ich = 0; ich < DetectorSpecs::GetME().NOpDets(); ++ich ) {
+        FLASH_DEBUG() << "ID | PMT | D | O | H " 
+        << one_measurement.idx << " " << ich << " " << one_hypothesis.closest_pds_v[ich] << " " << one_measurement.pe_v[ich] << " " << one_hypothesis.pe_v[ich] << std::endl;
+        if (one_hypothesis.closest_pds_v[ich] < _distance_threshold && one_measurement.pe_v[ich] == 0 && _channel_mask.at(ich)) {
+          FLASH_DEBUG() << "Setting " << ich << " to 0 due to distance threshold" << std::endl; //TODO: Set to flash info level
+          one_hypothesis.pe_v[ich] = 0;
         }
       }
     }
@@ -268,8 +283,12 @@ namespace flashmatch {
       if (msum!=0) for (auto &v : one_measurement.pe_v) v /= msum;
       // Scale the pe normalization factor if normalizing the flashes and hypothesis
       FLASH_DEBUG() << "Scaling observation threshold by " << 1/msum << std::endl;
-      if (msum!=0) _pe_observation_threshold_scaled = _pe_observation_threshold / msum;
-      FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << std::endl;
+      if (msum!=0){
+        _pe_observation_threshold_scaled = _pe_observation_threshold / msum; // Not used, but keep in case one wants to use it at a later date
+        _chi_error_min_scaled = _chi_error_min / msum;
+      }
+
+      FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << " and chi error min: " << _chi_error_min_scaled << std::endl;
     }
 
     // perform likelihood calculation
@@ -425,7 +444,7 @@ namespace flashmatch {
       if( H < 0 ) throw OpT0FinderException("Cannot have hypothesis value < 0!");
       if (std::isnan(H)) throw OpT0FinderException("Hypothesis value is nan!");
 
-      if(O < _pe_observation_threshold_scaled) ++count_observation;
+      if(O < _pe_observation_threshold) ++count_observation;
       if(H < _pe_hypothesis_threshold ) ++count_hypothesis;
     }
     FLASH_DEBUG() << count_observation << " (Reco) v.s. " << count_hypothesis << " (Hypothesis) PMTs below PE threshold " << std::endl;
@@ -439,6 +458,9 @@ namespace flashmatch {
 
       // Skip if the PMT is not masked (it should be used)
       if (_channel_mask[pmt_index] == 0) continue;
+
+      // Skip if the hypothesis and measurement are both 0. This means the PMT is saturated (or assumed to be saturated)
+      if (hypothesis.pe_v[pmt_index] == 0 && measurement.pe_v[pmt_index] == 0) continue;
       
       O = measurement.pe_v[pmt_index] / integral_factor; // observation
       H = hypothesis.pe_v[pmt_index];  // hypothesis
@@ -446,12 +468,12 @@ namespace flashmatch {
       if( H < 0 ) throw OpT0FinderException("Cannot have hypothesis value < 0!");
 
       // O(bservation) must be above threshold if set
-      if(O < _pe_observation_threshold_scaled) {
+      if(O < _pe_observation_threshold) {
         if (!_penalty_value_v.empty()) {
           O = _penalty_value_v[pmt_index];
         }
         else {
-          O = _pe_observation_threshold_scaled;
+          O = _pe_observation_threshold;
         }
       }
 
@@ -525,7 +547,7 @@ namespace flashmatch {
       	//nvalid_pmt += 1;
 
       } else if (_mode == kChi2) {
-        Error = std::max(O, _pe_observation_threshold_scaled);
+        Error = std::max(O, _chi_error_min_scaled);
         double chi2 = std::pow((O - H), 2) / (Error);
         _current_chi2 += chi2;
         FLASH_DEBUG() <<"CH | O | H | E | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << Error << ", " << chi2 << std::endl;

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -31,8 +31,9 @@ namespace flashmatch {
     _normalize = pset.get<bool>("NormalizeHypothesis");
     _mode   = (QLLMode_t)(pset.get<unsigned short>("QLLMode"));
     _chi_error = pset.get<double>("ChiErrorWidth", 0.1);
-    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.e-6);
+    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.); // We use 1.0 PE as the threshold, so if anything is below this, it is set to 0. This is to avoid divergences in the likelihood function.
     _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold", 1.e-6);
+    _pe_observation_threshold_scaled = _pe_observation_threshold;
     _migrad_tolerance         = pset.get<double>("MIGRADTolerance", 0.1);
     _offset                   = pset.get<double>("Offset", 0.0);
 		_time_shift               = pset.get<double>("BeamTimeShift", 0.0);
@@ -194,7 +195,7 @@ namespace flashmatch {
   }
 
   FlashMatch_t QLLMatch::OnePMTSpectrumMatch(const Flash_t& flash){
-    
+    _converged = true; // This states that we are just going to use the x0 from the TPC. Use many-to-many to do the full fit of possible x0s.
     FlashMatch_t res;
     res.score=-1;
     res.num_steps = 1;
@@ -223,7 +224,7 @@ namespace flashmatch {
       for (size_t ich = 0; ich < DetectorSpecs::GetME().NOpDets(); ++ich ) {
         // if above the saturated threshold, measured is zero, is a PMT, and is not masked 
         if ((one_hypothesis.pe_v[ich] >= _saturated_thresh) && (one_measurement.pe_v[ich] == 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0)){
-          FLASH_WARNING() << "Guessing " << ich << " is saturated, setting hypothesis to 0" << std::endl;
+          FLASH_DEBUG() << "Guessing " << ich << " is saturated, setting hypothesis to 0" << std::endl;
           one_hypothesis.pe_v[ich] = 0;
           continue;
         }
@@ -237,8 +238,15 @@ namespace flashmatch {
     // ** end saturated + nonlinear fix ** 
 
     res.hypothesis = one_hypothesis.pe_v;
+
     
     if (_normalize){
+      // Scale the pe normalization factor if normalizing the flashes and hypothesis
+      FLASH_DEBUG() << "Scaling observation threshold by " << 1/one_measurement.TotalPE() << std::endl;
+      _pe_observation_threshold_scaled = _pe_observation_threshold / one_measurement.TotalPE();
+      FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << std::endl;
+      // FLASH_DEBUG() << "Scaling hypothesis threshold by " << 1/_hypothesis.TotalPE() << std::endl;
+      //_pe_hypothesis_threshold /= _hypothesis.TotalPE();
       double hsum = std::accumulate(one_hypothesis.pe_v.begin(),  one_hypothesis.pe_v.end(), 0.0);
       double msum = std::accumulate(one_measurement.pe_v.begin(), one_measurement.pe_v.end(), 0.0);
       if (hsum!=0) for (auto &v : one_hypothesis.pe_v) v /= hsum;
@@ -382,6 +390,7 @@ namespace flashmatch {
     for(size_t i=0; i<_exp_frac_v.size(); ++i) {
       integral_factor += _exp_frac_v[i] * (1 - exp(-1 * measurement.time_width / _exp_tau_v[i]));
     }
+    FLASH_INFO() << "Integral factor: " << integral_factor << std::endl;
     assert(integral_factor > 0);
 
     double O, H, Error;
@@ -397,25 +406,33 @@ namespace flashmatch {
       if( H < 0 ) throw OpT0FinderException("Cannot have hypothesis value < 0!");
       if (std::isnan(H)) throw OpT0FinderException("Hypothesis value is nan!");
 
-      if(O < _pe_observation_threshold) ++count_observation;
+      if(O < _pe_observation_threshold_scaled) ++count_observation;
       if(H < _pe_hypothesis_threshold ) ++count_hypothesis;
     }
     FLASH_DEBUG() << count_observation << " (Reco) v.s. " << count_hypothesis << " (Hypothesis) PMTs below PE threshold " << std::endl;
+    for (size_t i = 0; i < measurement.pe_v.size(); ++i) {
+      if (measurement.pe_v[i] > 0) {
+        FLASH_DEBUG() << "Measurement PE: " << i << " " << measurement.pe_v[i] << std::endl;
+      }
+    }
 
     for (size_t pmt_index = 0; pmt_index < hypothesis.pe_v.size(); ++pmt_index) {
 
+      // Skip if the PMT is not masked (it should be used)
+      if (_channel_mask[pmt_index] == 0) continue;
+      
       O = measurement.pe_v[pmt_index] / integral_factor; // observation
       H = hypothesis.pe_v[pmt_index];  // hypothesis
 
       if( H < 0 ) throw OpT0FinderException("Cannot have hypothesis value < 0!");
 
       // O(bservation) must be above threshold if set
-      if(O < _pe_observation_threshold) {
+      if(O < _pe_observation_threshold_scaled) {
         if (!_penalty_value_v.empty()) {
           O = _penalty_value_v[pmt_index];
         }
         else {
-          O = _pe_observation_threshold;
+          O = _pe_observation_threshold_scaled;
         }
       }
 
@@ -450,7 +467,7 @@ namespace flashmatch {
       }
       else if(_mode == kZIP) {
         double pzero = H > _pe_hypothesis_threshold ? 0. : 1.;
-        double arg = O > _pe_observation_threshold ? (TMath::Poisson(O,H) * (1-pzero) + epsilon) : (pzero + (1 - pzero)*TMath::Exp(-H) + epsilon);
+        double arg = O > _pe_observation_threshold_scaled ? (TMath::Poisson(O,H) * (1-pzero) + epsilon) : (pzero + (1 - pzero)*TMath::Exp(-H) + epsilon);
         if(!std::isnan(arg) && !std::isinf(arg)) {
             _current_llhd -= std::log10(arg);
             nvalid_pmt += 1;
@@ -490,11 +507,13 @@ namespace flashmatch {
 
       } else if (_mode == kChi2) {
 
-      	// Error = O;
-        Error = H;
-        // if( Error < 1.0 ) Error = 1.0;
-        _current_chi2 += std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2));
-        //if(!(O==_pe_observation_threshold && H == _pe_hypothesis_threshold)) std::cout <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << std::pow((O - H), 2) / (Error + std::pow(0.1*Error,2)) << std::endl;
+      	Error = O;
+        //Error = (std::pow(H*_chi_error,2)+O);
+        if( Error < 1.0 ) Error = 1.0;
+        //double chi2 = std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2));
+        double chi2 = std::pow((O - H), 2) / (Error);
+        _current_chi2 += chi2;
+        if(!(O==_pe_observation_threshold_scaled && H == _pe_hypothesis_threshold)) FLASH_DEBUG() <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2)) << std::endl;
         nvalid_pmt += 1;
 
       } else {
@@ -508,6 +527,7 @@ namespace flashmatch {
 
     if(_converged)
       FLASH_INFO() << "Combined LLHD: " << _current_llhd << " (divided by nvalid_pmt+1 = " << nvalid_pmt+1<<")"<<std::endl;
+      FLASH_INFO() << "Combined Chi2: " << _current_chi2 << " (divided by nvalid_pmt = " << nvalid_pmt<<")"<<std::endl;
 
     return (_mode == kChi2 ? _current_chi2 : _current_llhd);
   }

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -77,10 +77,21 @@ namespace flashmatch {
     _vol_xmin = bbox.Min()[0];
 
     // Configuration statements
-    FLASH_NORMAL() << "QLLMatch configuration: " << std::endl;
-    FLASH_NORMAL() << "  - Mode: " << _mode << std::endl;
-    FLASH_NORMAL() << "  - PE observation threshold: " << _pe_observation_threshold << std::endl;
-    FLASH_NORMAL() << "  - PE hypothesis threshold: " << _pe_hypothesis_threshold << std::endl;
+    FLASH_NORMAL() << "Mode: " << _mode << std::endl;
+    FLASH_NORMAL() << "PE observation threshold: " << _pe_observation_threshold << std::endl;
+    FLASH_NORMAL() << "PE hypothesis threshold: " << _pe_hypothesis_threshold << std::endl;
+    FLASH_NORMAL() << "Chi error width: " << _chi_error << std::endl;
+    FLASH_NORMAL() << "Normalize: " << _normalize << std::endl;
+    FLASH_NORMAL() << "MIGRAD tolerance: " << _migrad_tolerance << std::endl;
+    FLASH_NORMAL() << "Offset: " << _offset << std::endl;
+    FLASH_NORMAL() << "Time shift: " << _time_shift << std::endl;
+    FLASH_NORMAL() << "Touching track window: " << _touching_track_window << std::endl;
+    FLASH_NORMAL() << "Minuit x buffer: " << _minuit_x_buffer << std::endl;
+    FLASH_NORMAL() << "Use many-to-many: " << _many_to_many << std::endl;
+    FLASH_NORMAL() << "Saturated threshold: " << _saturated_thresh << std::endl;
+    FLASH_NORMAL() << "Nonlinear threshold: " << _nonlinear_thresh << std::endl;
+    FLASH_NORMAL() << "Nonlinear slope: " << _nonlinear_slope << std::endl;
+    FLASH_NORMAL() << "Nonlinear offset: " << _nonlinear_offset << std::endl;
     
   }
 
@@ -229,6 +240,8 @@ namespace flashmatch {
     //   measured flash PE was set to 0 due to saturation
     if (_saturated_thresh > 0){
       for (size_t ich = 0; ich < DetectorSpecs::GetME().NOpDets(); ++ich ) {
+        FLASH_DEBUG() << "Checking " << ich << " for saturation" << std::endl;
+        FLASH_DEBUG() << "Hypothesis: " << one_hypothesis.pe_v[ich] << " Measurement: " << one_measurement.pe_v[ich] << std::endl;
         // if above the saturated threshold, measured is zero, is a PMT, and is not masked 
         if ((one_hypothesis.pe_v[ich] >= _saturated_thresh) && (one_measurement.pe_v[ich] == 0) && (_channel_type[ich] == 0) && (_match_mask.at(ich) == 0) && _channel_mask.at(ich)){
           FLASH_DEBUG() << "Guessing " << ich << " is saturated, setting hypothesis to 0" << std::endl;
@@ -253,9 +266,10 @@ namespace flashmatch {
       double msum = std::accumulate(one_measurement.pe_v.begin(), one_measurement.pe_v.end(), 0.0);
       if (hsum!=0) for (auto &v : one_hypothesis.pe_v) v /= hsum;
       if (msum!=0) for (auto &v : one_measurement.pe_v) v /= msum;
+      _msum = msum; // store the sum of PE in the measurement before any normalization
+      _hsum = hsum; // store the sum of PE in the hypothesis before any normalization
       // Scale the pe normalization factor if normalizing the flashes and hypothesis
       FLASH_DEBUG() << "Scaling observation threshold by " << 1/msum << std::endl;
-      FLASH_DEBUG() << "Measurement total PE: " << one_measurement.TotalPE() << std::endl;
       if (msum!=0) _pe_observation_threshold_scaled = _pe_observation_threshold / msum;
       FLASH_DEBUG() << "New observation threshold: " << _pe_observation_threshold_scaled << std::endl;
     }
@@ -513,13 +527,10 @@ namespace flashmatch {
       	//nvalid_pmt += 1;
 
       } else if (_mode == kChi2) {
-
-      	Error = O;
-        //Error = (std::pow(H*_chi_error,2)+O);
-        if( Error < _pe_observation_threshold_scaled ) Error = _pe_observation_threshold_scaled;
+        Error = std::max(O, _pe_observation_threshold_scaled);
         double chi2 = std::pow((O - H), 2) / (Error);
         _current_chi2 += chi2;
-        FLASH_DEBUG() <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << chi2 << std::endl;
+        FLASH_DEBUG() <<"CH | O | H | E | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << Error << ", " << chi2 << std::endl;
         nvalid_pmt += 1;
 
       } 

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -31,7 +31,7 @@ namespace flashmatch {
     _normalize = pset.get<bool>("NormalizeHypothesis");
     _mode   = (QLLMode_t)(pset.get<unsigned short>("QLLMode"));
     _chi_error = pset.get<double>("ChiErrorWidth", 0.1);
-    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.); // We use 1.0 PE as the threshold, so if anything is below this, it is set to 0. This is to avoid divergences in the likelihood function.
+    _pe_observation_threshold = pset.get<double>("PEObservationThreshold", 1.); // This is to avoid divergences in the likelihood function. Asserts a lower bound on the statistical uncertainty in PE.
     _pe_hypothesis_threshold  = pset.get<double>("PEHypothesisThreshold", 1.e-6);
     _pe_observation_threshold_scaled = _pe_observation_threshold;
     _migrad_tolerance         = pset.get<double>("MIGRADTolerance", 0.1);

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -249,8 +249,6 @@ namespace flashmatch {
 
     
     if (_normalize){
-      // FLASH_DEBUG() << "Scaling hypothesis threshold by " << 1/_hypothesis.TotalPE() << std::endl;
-      //_pe_hypothesis_threshold /= _hypothesis.TotalPE();
       double hsum = std::accumulate(one_hypothesis.pe_v.begin(),  one_hypothesis.pe_v.end(), 0.0);
       double msum = std::accumulate(one_measurement.pe_v.begin(), one_measurement.pe_v.end(), 0.0);
       if (hsum!=0) for (auto &v : one_hypothesis.pe_v) v /= hsum;

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -522,7 +522,6 @@ namespace flashmatch {
         //double chi2 = std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2));
         double chi2 = std::pow((O - H), 2) / (Error);
         _current_chi2 += chi2;
-        //if(!(O==_pe_observation_threshold_scaled && H == _pe_hypothesis_threshold)) 
         FLASH_DEBUG() <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << chi2 << std::endl;
         nvalid_pmt += 1;
 

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -390,7 +390,7 @@ namespace flashmatch {
     for(size_t i=0; i<_exp_frac_v.size(); ++i) {
       integral_factor += _exp_frac_v[i] * (1 - exp(-1 * measurement.time_width / _exp_tau_v[i]));
     }
-    FLASH_INFO() << "Integral factor: " << integral_factor << std::endl;
+    FLASH_DEBU() << "Integral factor: " << integral_factor << std::endl;
     assert(integral_factor > 0);
 
     double O, H, Error;

--- a/flashmatch/Algorithms/QLLMatch.cxx
+++ b/flashmatch/Algorithms/QLLMatch.cxx
@@ -519,7 +519,6 @@ namespace flashmatch {
       	Error = O;
         //Error = (std::pow(H*_chi_error,2)+O);
         if( Error < _pe_observation_threshold_scaled ) Error = _pe_observation_threshold_scaled;
-        //double chi2 = std::pow((O - H), 2) / (Error + std::pow(_chi_error*Error,2));
         double chi2 = std::pow((O - H), 2) / (Error);
         _current_chi2 += chi2;
         FLASH_DEBUG() <<"CH | O | H | chisq : "<<pmt_index<<", " << O << ", " << H << ", " << chi2 << std::endl;

--- a/flashmatch/Algorithms/QLLMatch.h
+++ b/flashmatch/Algorithms/QLLMatch.h
@@ -128,6 +128,7 @@ namespace flashmatch {
     std::vector<double>  _penalty_value_v;
     double _pe_hypothesis_threshold;
     double _pe_observation_threshold;
+    double _pe_observation_threshold_scaled; ///< Scaled observation threshold, happens when normalizing the hypothesis and measurement
 
     flashmatch::QCluster_t _raw_trk;
     QPoint_t _raw_xmin_pt;

--- a/flashmatch/Algorithms/QLLMatch.h
+++ b/flashmatch/Algorithms/QLLMatch.h
@@ -44,7 +44,7 @@ namespace flashmatch {
 
   public:
 
-    enum QLLMode_t { kChi2, kLLHD, kSimpleLLHD, kWeightedLLHD, kIntegralLLHD, kZIP, kPEWeightedLLHD };
+    enum QLLMode_t { kChi2, kLLHD, kSimpleLLHD, kWeightedLLHD, kIntegralLLHD, kZIP, kPEWeightedLLHD, kGStat };
 
   private:
     /// Valid ctor hidden (singleton)

--- a/flashmatch/Algorithms/QLLMatch.h
+++ b/flashmatch/Algorithms/QLLMatch.h
@@ -181,6 +181,9 @@ namespace flashmatch {
     double _nonlinear_thresh; // parameters to correct for nonlinear **PMT** effects
     double _nonlinear_slope;  // parameters to correct for nonlinear **PMT** effects
     double _nonlinear_offset; // parameters to correct for nonlinear **PMT** effects
+
+    double _msum=1.; // sum of PE in the measurement before any normalization
+    double _hsum=1.; // sum of PE in the hypothesis before any normalization
   };
 
   /**

--- a/flashmatch/Algorithms/QLLMatch.h
+++ b/flashmatch/Algorithms/QLLMatch.h
@@ -121,6 +121,8 @@ namespace flashmatch {
     bool _record;      ///< Boolean switch to record minimizer history
     double _normalize; ///< Noramalize hypothesis PE spectrum
     double _chi_error; ///< width of an additional uncertainty to add to Chi2 method 
+    double _chi_error_min; ///< minimum poisson uncertainty on flash in PE.
+    double _chi_error_min_scaled; ///< Normalized flashes are scaled by total PE.
     bool _check_touching_track; ///< Whether to match immediately touching track with flash if timing coincides.
     double _touching_track_window; ///< Time(us) such that we use this tolerance T to find touching tracks
 
@@ -178,6 +180,7 @@ namespace flashmatch {
     std::vector<int> _match_mask; ///< OpDet Channel Mask for a cluster+flash pair 
 
     double _saturated_thresh; // threshold for hypothesis PE to ignore due to saturated measured PE 
+    double _distance_threshold; // threshold for distance to PMT to ignore due to saturation
     double _nonlinear_thresh; // parameters to correct for nonlinear **PMT** effects
     double _nonlinear_slope;  // parameters to correct for nonlinear **PMT** effects
     double _nonlinear_offset; // parameters to correct for nonlinear **PMT** effects

--- a/flashmatch/Algorithms/QLLMatch.h
+++ b/flashmatch/Algorithms/QLLMatch.h
@@ -130,7 +130,6 @@ namespace flashmatch {
     std::vector<double>  _penalty_value_v;
     double _pe_hypothesis_threshold;
     double _pe_observation_threshold;
-    double _pe_observation_threshold_scaled; ///< Scaled observation threshold, happens when normalizing the hypothesis and measurement
 
     flashmatch::QCluster_t _raw_trk;
     QPoint_t _raw_xmin_pt;

--- a/flashmatch/Algorithms/QLLMatch.h
+++ b/flashmatch/Algorithms/QLLMatch.h
@@ -181,9 +181,6 @@ namespace flashmatch {
     double _nonlinear_thresh; // parameters to correct for nonlinear **PMT** effects
     double _nonlinear_slope;  // parameters to correct for nonlinear **PMT** effects
     double _nonlinear_offset; // parameters to correct for nonlinear **PMT** effects
-
-    double _msum=1.; // sum of PE in the measurement before any normalization
-    double _hsum=1.; // sum of PE in the hypothesis before any normalization
   };
 
   /**

--- a/flashmatch/Algorithms/SelectionGreedy.cxx
+++ b/flashmatch/Algorithms/SelectionGreedy.cxx
@@ -19,7 +19,6 @@ namespace flashmatch {
     _allow_reuse_flash = pset.get<bool>("AllowReuseFlash",false);
     _invert_score = pset.get<bool>("InvertScore",true);
 
-    FLASH_NORMAL() << "SelectionGreedy::_Configure_() called" << std::endl;
     FLASH_NORMAL() << "TouchMatchMaxThreshold: " << _score_max_threshold << std::endl;
     FLASH_NORMAL() << "FlashScoreMinThreshold: " << _score_min_threshold << std::endl;
     FLASH_NORMAL() << "FlashScoreMaxCeiling: " << _score_max_ceiling << std::endl;

--- a/flashmatch/Algorithms/SelectionGreedy.cxx
+++ b/flashmatch/Algorithms/SelectionGreedy.cxx
@@ -19,12 +19,12 @@ namespace flashmatch {
     _allow_reuse_flash = pset.get<bool>("AllowReuseFlash",false);
     _invert_score = pset.get<bool>("InvertScore",true);
 
-    std::cout << "SelectionGreedy::_Configure_() called" << std::endl;
-    std::cout << "TouchMatchMaxThreshold: " << _score_max_threshold << std::endl;
-    std::cout << "FlashScoreMinThreshold: " << _score_min_threshold << std::endl;
-    std::cout << "FlashScoreMaxCeiling: " << _score_max_ceiling << std::endl;
-    std::cout << "AllowReuseFlash: " << _allow_reuse_flash << std::endl;
-    std::cout << "InvertScore: " << _invert_score << std::endl;
+    FLASH_NORMAL() << "SelectionGreedy::_Configure_() called" << std::endl;
+    FLASH_NORMAL() << "TouchMatchMaxThreshold: " << _score_max_threshold << std::endl;
+    FLASH_NORMAL() << "FlashScoreMinThreshold: " << _score_min_threshold << std::endl;
+    FLASH_NORMAL() << "FlashScoreMaxCeiling: " << _score_max_ceiling << std::endl;
+    FLASH_NORMAL() << "AllowReuseFlash: " << _allow_reuse_flash << std::endl;
+    FLASH_NORMAL() << "InvertScore: " << _invert_score << std::endl;
   }
 
   std::vector<FlashMatch_t> SelectionGreedy::Select(const std::vector<std::vector<FlashMatch_t> >& match_data)
@@ -81,6 +81,7 @@ namespace flashmatch {
     score_map.clear();
 
     // Step 2.1 register matches with a flash-match score (inverse in order to use multimap)
+    FLASH_DEBUG() << "Original match_data values: " << std::endl;
     for(auto const& match_v : match_data) {
       for(auto const& match : match_v) {
         FLASH_DEBUG() << "match.score: " << match.score 
@@ -101,6 +102,10 @@ namespace flashmatch {
       auto const& tpc_index   = match_info.tpc_id;   // matched tpc original id
       auto const& flash_index = match_info.flash_id; // matched flash original id
 
+      FLASH_DEBUG() << "match_info.score: " << match_info.score 
+      << " match_info.tpc_id: " << match_info.tpc_id
+      << " match_info.flash_id: " << match_info.flash_id
+      << std::endl;
 
       // If this tpc object is already assigned (=better match found), ignore
       if (tpc_used.find(tpc_index) != tpc_used.end()) continue;

--- a/flashmatch/Algorithms/SemiAnalyticalModel.cxx
+++ b/flashmatch/Algorithms/SemiAnalyticalModel.cxx
@@ -184,15 +184,16 @@ namespace flashmatch{
     if(flash.pe_v.empty()) flash.pe_v.resize(fNOpDets);
     if(flash.pe_err_v.empty()) flash.pe_err_v.resize(fNOpDets);
     if(flash.pe_true_v.empty()) flash.pe_true_v.resize(fNOpDets);
+    if(flash.closest_pds_v.empty()) flash.closest_pds_v.resize(fNOpDets);
 
     assert(flash.pe_v.size()     == fNOpDets);
     assert(flash.pe_true_v.size() == fNOpDets);
     assert(flash.pe_err_v.size() == fNOpDets);
-
+    assert(flash.closest_pds_v.size() == fNOpDets);
     for (auto& v : flash.pe_v      ) {v = 0;}
     for (auto& v : flash.pe_err_v  ) {v = 0;}
     for (auto& v : flash.pe_true_v ) {v = 0;}
-
+    for (auto& v : flash.closest_pds_v) {v = 1.e9;}
     // Temporary for printout
     double q_tot = 0;
     // end of temporary for printout
@@ -236,11 +237,13 @@ namespace flashmatch{
         double q = n_original_photons * visibility * _global_qe * _qe_v[op_det];
 
         flash.pe_v[op_det] += q;
-        // if (std::find(_channel_mask.begin(), _channel_mask.end(), op_det) != _channel_mask.end()) {
-        //   flash.pe_v[op_det] += q;
-        // } else {
-        //   flash.pe_v[op_det] = 0;
-        // }
+        geoalgo::Point_t const op_det_pos = fOpDetector[op_det].center;
+        // Update the closest distance to the PMT - only need to do this with direct or indirect light, add the visibility check if the charge is in a separate TPC.
+        double distance = (xyz - op_det_pos).Length();
+        if (distance < flash.closest_pds_v[op_det] && visibility > 0) {
+          FLASH_DEBUG() << "Updating closest distance to PMT " << op_det << " to " << distance << std::endl;
+          flash.closest_pds_v[op_det] = distance;
+        }
       }
 
       //
@@ -254,11 +257,6 @@ namespace flashmatch{
         double q = n_original_photons * visibility * _global_qe_refl * _qe_refl_v[op_det];
 
         flash.pe_v[op_det] += q;
-        // if (std::find(_channel_mask.begin(), _channel_mask.end(), op_det) != _channel_mask.end()) {
-        //   flash.pe_v[op_det] += q;
-        // } else {
-        //   flash.pe_v[op_det] = 0;
-        // }
       }
     }
     //Count number of valid channels
@@ -285,6 +283,7 @@ namespace flashmatch{
     << " trk.size(): " << trk.size()
     << "Flash [x,y,z] -> [Total PE] : [" << flash.x << ", " << flash.y << ", " << flash.z << "] -> [" << flash.TotalPE() << "]"
     << " q_total: " << q_tot
+    << " closest_pds_v (first 10): " << flash.closest_pds_v[0] << ", " << flash.closest_pds_v[1] << ", " << flash.closest_pds_v[2] << ", " << flash.closest_pds_v[3] << ", " << flash.closest_pds_v[4] << ", " << flash.closest_pds_v[5] << ", " << flash.closest_pds_v[6] << ", " << flash.closest_pds_v[7] << ", " << flash.closest_pds_v[8] << ", " << flash.closest_pds_v[9]
     << " idx: " << flash.idx << std::endl;
     // Check validity of flash
     if (!flash.Valid(fNOpDets)) {

--- a/flashmatch/Algorithms/SemiAnalyticalModel.cxx
+++ b/flashmatch/Algorithms/SemiAnalyticalModel.cxx
@@ -228,6 +228,9 @@ namespace flashmatch{
       // Fill Estimate with Direct light
       //
       for (size_t op_det=0; op_det<direct_visibilities.size(); ++op_det) {
+        if (_channel_mask[op_det] == false) {
+          continue;
+        }
         const double visibility = direct_visibilities[op_det];
 
         double q = n_original_photons * visibility * _global_qe * _qe_v[op_det];
@@ -244,6 +247,9 @@ namespace flashmatch{
       // Fill Estimate with Reflected light
       //
       for (size_t op_det=0; op_det<reflected_visibilities.size(); ++op_det) {
+        if (_channel_mask[op_det] == false) {
+          continue;
+        }
         const double visibility = reflected_visibilities[op_det];
         double q = n_original_photons * visibility * _global_qe_refl * _qe_refl_v[op_det];
 
@@ -274,7 +280,7 @@ namespace flashmatch{
     // }
     
     // Print outs to check validity of filling the flashes
-    FLASH_DEBUG() << "Filled flash with " << _channel_mask.size() << " PMTs ... " 
+    FLASH_INFO() << "Filled flash with " << _channel_mask.size() << " PMTs ... " 
     << " Valid: " << flash.Valid(fNOpDets) << " Total PE: " << flash.TotalPE() 
     << " trk.size(): " << trk.size()
     << "Flash [x,y,z] -> [Total PE] : [" << flash.x << ", " << flash.y << ", " << flash.z << "] -> [" << flash.TotalPE() << "]"
@@ -288,6 +294,11 @@ namespace flashmatch{
       << " flash.pe_err_v.size() " << flash.pe_err_v.size()
       << " flash.idx " << flash.idx << std::endl;
       throw OpT0FinderException();
+    }
+    for (size_t op_det=0; op_det<flash.pe_v.size(); ++op_det) {
+      if (flash.pe_v[op_det] > 0) {
+        FLASH_DEBUG()<<"op_det: "<<op_det<<" pe_v: "<<flash.pe_v[op_det]<<std::endl;
+      }
     }
 
   }

--- a/flashmatch/Base/BaseFlashHypothesis.cxx
+++ b/flashmatch/Base/BaseFlashHypothesis.cxx
@@ -24,6 +24,11 @@ namespace flashmatch {
     if(!_chs_to_use.empty()) {
       this->SetChannelMask(_chs_to_use); // This will set the channel mask based on the channel ids
     }
+    else { //assume all channels are used
+      for (size_t i = 0; i < _channel_mask.size(); i++) {
+        _channel_mask[i] = true;
+      }
+    }
 
     _qe_v.clear();
     _qe_v = pset.get<std::vector<double> >("CCVCorrection",_qe_v);

--- a/flashmatch/Base/BaseFlashHypothesis.cxx
+++ b/flashmatch/Base/BaseFlashHypothesis.cxx
@@ -20,7 +20,7 @@ namespace flashmatch {
     _global_qe_refl = pset.get<double>("GlobalQERefl", -1);
 
     // This is meant to be a list of channel ids to use
-    _chs_to_use = pset.get<std::vector<int> >("ChannelsToUse",_chs_to_use);
+    _chs_to_use = pset.get<std::vector<int> >("ChannelToUse",_chs_to_use);
     if(!_chs_to_use.empty()) {
       this->SetChannelMask(_chs_to_use); // This will set the channel mask based on the channel ids
     }

--- a/flashmatch/Base/BaseFlashHypothesis.cxx
+++ b/flashmatch/Base/BaseFlashHypothesis.cxx
@@ -7,7 +7,7 @@ namespace flashmatch {
 
   BaseFlashHypothesis::BaseFlashHypothesis(std::string name)
     : BaseAlgorithm(kFlashHypothesis,name)
-    , _channel_mask(DetectorSpecs::GetME().NOpDets(),false)
+    , _channel_mask(DetectorSpecs::GetME().NOpDets(),true)
     , _uncoated_pmt_list(DetectorSpecs::GetME().NOpDets(),false)
   {}
 
@@ -19,6 +19,12 @@ namespace flashmatch {
     _global_qe = pset.get<double>("GlobalQE");
     _global_qe_refl = pset.get<double>("GlobalQERefl", -1);
 
+    // This is meant to be a list of channel ids to use
+    _chs_to_use = pset.get<std::vector<int> >("ChannelsToUse",_chs_to_use);
+    if(!_chs_to_use.empty()) {
+      this->SetChannelMask(_chs_to_use); // This will set the channel mask based on the channel ids
+    }
+
     _qe_v.clear();
     _qe_v = pset.get<std::vector<double> >("CCVCorrection",_qe_v);
     if(_qe_v.empty()) _qe_v.resize(DetectorSpecs::GetME().NOpDets(),1.0);
@@ -29,6 +35,8 @@ namespace flashmatch {
     }
 
     //Debug statements
+    FLASH_DEBUG() << "Channel mask size: " << _channel_mask.size() << std::endl;
+    FLASH_DEBUG() << "fNOpDets: " << DetectorSpecs::GetME().NOpDets() << std::endl;
     for(size_t i=0; i<_channel_mask.size(); ++i) {
       FLASH_DEBUG() << "Channel " << i << " is masked to " << _channel_mask[i] << std::endl;
     }

--- a/flashmatch/Base/BaseFlashHypothesis.h
+++ b/flashmatch/Base/BaseFlashHypothesis.h
@@ -45,9 +45,17 @@ namespace flashmatch {
     void InitializeMask(Flash_t &flash) const;
 
     /// Sets the channels to use
-    void SetChannelMask(std::vector<int> ch_mask) { 
-      FLASH_DEBUG() << "Setting channel mask: " << ch_mask.size() << std::endl;
-      _channel_mask = ch_mask;
+    void SetChannelMask(std::vector<int> ch_to_use) { 
+      // Initialize all channels to false
+      FLASH_DEBUG() << "ch_to_use size: " << ch_to_use.size() << std::endl;
+      for (size_t i = 0; i < _channel_mask.size(); i++) {
+        _channel_mask[i] = false;
+      }
+      // Set the channels to use to true
+      for (size_t i = 0; i < ch_to_use.size(); i++) {
+        FLASH_DEBUG() << "Setting channel mask: " << ch_to_use[i] << " to true" << std::endl;
+        _channel_mask[ch_to_use[i]] = true;
+      }
     }
 
     /// Sets the channel type (pmt vs. xarapuca)
@@ -59,7 +67,8 @@ namespace flashmatch {
   protected:
 
     std::vector<int> _channel_type; 
-    std::vector<int> _channel_mask; ///< The list of channels mask use of
+    std::vector<int> _chs_to_use; ///< The list of channels mask use of
+    std::vector<bool> _channel_mask; ///< The list of channels mask use of
     std::vector<int> _uncoated_pmt_list; ///< A list of opdet sensitive to visible (reflected) light
     double _threshold_proximity; ///< Threshold for proximity
     double _segment_size; ///< Segment size

--- a/flashmatch/Base/BaseFlashMatch.h
+++ b/flashmatch/Base/BaseFlashMatch.h
@@ -67,7 +67,15 @@ namespace flashmatch {
     flashmatch::BaseFlashHypothesis* _flash_hypothesis;
 
     /// Sets the channels to use
-    void SetChannelMask(std::vector<int> ch_mask) {_channel_mask = ch_mask; }
+    void SetChannelMask(std::vector<int> ch_mask) {
+      // Initialize all channels to false
+      _channel_mask.resize(DetectorSpecs::GetME().NOpDets(),false);
+      // Set the channels to use to true
+      for (size_t i = 0; i < ch_mask.size(); ++i) {
+        FLASH_DEBUG() << "Setting channel mask: " << ch_mask[i] << " to true" << std::endl;
+        _channel_mask[ch_mask[i]] = true;
+      }
+    }
 
     /// Sets the channel type (pmt vs arapuca)
     void SetChannelType(std::vector<int> ch_type) {_channel_type = ch_type; }
@@ -85,7 +93,7 @@ namespace flashmatch {
     int _cryo = 0; ///< The Cryostat number to use
     double _vol_xmax, _vol_xmin; //Max and min x values of the active volume
 
-    std::vector<int> _channel_mask; ///< The list of channels to use
+    std::vector<bool> _channel_mask; ///< The list of channels to use
     std::vector<int> _channel_type;
 
 

--- a/flashmatch/Base/FlashMatchManager.cxx
+++ b/flashmatch/Base/FlashMatchManager.cxx
@@ -81,7 +81,7 @@ namespace flashmatch {
       //Make a list ranging from 0 to NOpDets
       ch_touse.resize(NOpDets);
       for (size_t i= 0; i <NOpDets; i++) {
-        ch_touse[i] = i;
+        ch_touse[i] = true;
       }
     }
     this->SetChannelMask(ch_touse);
@@ -413,6 +413,9 @@ namespace flashmatch {
   void FlashMatchManager::SetChannelMask(std::vector<int> ch_touse) {
 
     //FIXME Set in detector config as well
+    for (size_t i = 0; i < ch_touse.size(); ++i) {
+      FLASH_DEBUG() << "Setting channel mask: " << ch_touse[i] << " to true" << std::endl;
+    }
 
     //Set in upstream algorithms
     if (!_alg_flash_hypothesis) {
@@ -421,7 +424,8 @@ namespace flashmatch {
 
     _alg_flash_hypothesis->SetChannelMask(ch_touse);
 
-      if (_alg_flash_match) {
+    if (_alg_flash_match) {
+      FLASH_DEBUG() << "Setting channel mask: " << std::endl;
       _alg_flash_match->SetChannelMask(ch_touse);
     }
   }

--- a/flashmatch/Base/FlashMatchManager.cxx
+++ b/flashmatch/Base/FlashMatchManager.cxx
@@ -81,7 +81,7 @@ namespace flashmatch {
       //Make a list ranging from 0 to NOpDets
       ch_touse.resize(NOpDets);
       for (size_t i= 0; i <NOpDets; i++) {
-        ch_touse[i] = true;
+        ch_touse[i] = i;
       }
     }
     this->SetChannelMask(ch_touse);

--- a/flashmatch/Base/FlashMatchManager.cxx
+++ b/flashmatch/Base/FlashMatchManager.cxx
@@ -425,7 +425,6 @@ namespace flashmatch {
     _alg_flash_hypothesis->SetChannelMask(ch_touse);
 
     if (_alg_flash_match) {
-      FLASH_DEBUG() << "Setting channel mask: " << std::endl;
       _alg_flash_match->SetChannelMask(ch_touse);
     }
   }

--- a/flashmatch/Base/OpT0FinderTypes.h
+++ b/flashmatch/Base/OpT0FinderTypes.h
@@ -44,6 +44,7 @@ namespace flashmatch {
     std::vector<double> pe_v; ///< PE distribution over photo-detectors
     std::vector<double> pe_true_v; ///< PE distribution over photo-detectors of MCFlash
     std::vector<double> pe_err_v; ///< PE value error
+    std::vector<double> closest_pds_v; ///< closest PDs to the flash
     double x,y,z;             ///< Flash position
     double x_err,y_err,z_err; ///< Flash position error
     double time;              ///< Flash timing, a candidate T0
@@ -54,7 +55,7 @@ namespace flashmatch {
     ID_t idx;                 ///< index from original larlite vector
     //ID_t ROOT_idx;            ///< index in root file
     /// Default ctor assigns invalid values
-    Flash_t() : pe_v(), pe_true_v() , pe_err_v() {
+    Flash_t() : pe_v(), pe_true_v() , pe_err_v(), closest_pds_v() {
       x = y = z = kINVALID_DOUBLE;
       x_err = y_err = z_err = kINVALID_DOUBLE;
       time = kINVALID_DOUBLE;
@@ -96,7 +97,7 @@ namespace flashmatch {
     }
     /// Check validity
     bool Valid(size_t nopdet=0) const {
-      return (nopdet ? (pe_v.size() == nopdet && pe_err_v.size() == nopdet) : (pe_v.size() == pe_err_v.size()));
+      return (nopdet ? (pe_v.size() == nopdet && pe_err_v.size() == nopdet && closest_pds_v.size() == nopdet) : (pe_v.size() == pe_err_v.size() && closest_pds_v.size() == pe_err_v.size()));
     }
     //double TotalPE() const{ return std::accumulate(pe_v.begin(),pe_v.end(),0.0);}
   };

--- a/flashmatch/Base/OpT0FinderTypes.h
+++ b/flashmatch/Base/OpT0FinderTypes.h
@@ -97,7 +97,7 @@ namespace flashmatch {
     }
     /// Check validity
     bool Valid(size_t nopdet=0) const {
-      return (nopdet ? (pe_v.size() == nopdet && pe_err_v.size() == nopdet && closest_pds_v.size() == nopdet) : (pe_v.size() == pe_err_v.size() && closest_pds_v.size() == pe_err_v.size()));
+      return (nopdet ? (pe_v.size() == nopdet && pe_err_v.size() == nopdet && closest_pds_v.size() == nopdet) : (pe_v.size() == pe_err_v.size()));
     }
     //double TotalPE() const{ return std::accumulate(pe_v.begin(),pe_v.end(),0.0);}
   };

--- a/flashmatch/Base/OpT0FinderTypes.h
+++ b/flashmatch/Base/OpT0FinderTypes.h
@@ -97,7 +97,7 @@ namespace flashmatch {
     }
     /// Check validity
     bool Valid(size_t nopdet=0) const {
-      return (nopdet ? (pe_v.size() == nopdet && pe_err_v.size() == nopdet && closest_pds_v.size() == nopdet) : (pe_v.size() == pe_err_v.size()));
+      return (nopdet ? (pe_v.size() == nopdet && pe_err_v.size() == nopdet) : (pe_v.size() == pe_err_v.size()));
     }
     //double TotalPE() const{ return std::accumulate(pe_v.begin(),pe_v.end(),0.0);}
   };

--- a/python/flashmatch/rootinput.py
+++ b/python/flashmatch/rootinput.py
@@ -194,9 +194,11 @@ class ROOTInput:
             flash.idx = f_idx
             pe_reco_v = f['pe_v']
             pe_true_v = f['pe_true_v']
+            closest_pds_v = f['closest_pds_v']
             flash.pe_v.resize(self.det.NOpDets(),0.)
             flash.pe_err_v.resize(self.det.NOpDets(),0.)
             flash.pe_true_v.resize(self.det.NOpDets(),0.)
+            flash.closest_pds_v.resize(self.det.NOpDets(),1.e9)
             for pmt in range(self.det.NOpDets()):
                 flash.pe_v[pmt] = pe_reco_v[pmt]
                 flash.pe_err_v[pmt] = 0.
@@ -204,6 +206,7 @@ class ROOTInput:
                 flash.time_width = f['time_width']
                 flash.pe_true_v[pmt] = pe_true_v[pmt]
                 flash.time_true = f['time_true']
+                flash.closest_pds_v[pmt] = closest_pds_v[pmt]
             if np.sum(flash.pe_v) > 0:
                 flash_v.append(flash)
         return flash_v


### PR DESCRIPTION
## Description

Set minimum uncertainty to be 1 PE to avoid divergences. Modify minimum PE to scale by total PE. Chi2 now uses standard poisson uncertainty on flash to evaluate score (no uncertainty assigned to hypothesis). 

Also added ability to set channels that are used, which can be set in the manager to be done for both the matching and hypothesis. Channels to use match will also not compute flash score for channels not in this list. The default behavior is to use all channels.

## MPR Studies
Studies from MPR samples shown below. There is a single species of a specified particle that is intime between 0-3 GeV. There's an additional 5 muons that are out of time between 0-3 GeV.

<img width="839" alt="Screenshot 2025-04-29 at 1 02 54 PM" src="https://github.com/user-attachments/assets/6e144695-93b7-4bfe-8a3d-582031658160" />

### Pion
![image](https://github.com/user-attachments/assets/82c602b5-a9a2-4b61-af2d-262f44a2baee)
![image](https://github.com/user-attachments/assets/67216615-5264-41b9-8871-eccedc483829)
### Electron
![image](https://github.com/user-attachments/assets/ff86f44e-e8fd-4e22-a27f-27c9459b4aae)
![image](https://github.com/user-attachments/assets/ecc056d4-e107-4303-9ec3-5d1ff60ab9a6)
### Muon
![image](https://github.com/user-attachments/assets/624f6c39-9e94-4896-9144-eef73b854737)
![image](https://github.com/user-attachments/assets/60aece63-5e4b-420d-b8d7-17e908e94cd6)
